### PR TITLE
Detect Tracker processor: refactor and streamline regex

### DIFF
--- a/processors/detect_trackers.py
+++ b/processors/detect_trackers.py
@@ -25,7 +25,7 @@ __email__ = "4cat@oilab.eu"
 
 csv.field_size_limit(1024 * 1024 * 1024)
 
-url_regex = re.compile(r"(https?:\/\/)?([a-zA-Z0-9.-]+\.)?[a-zA-Z0-9.-]+(?=[\/\?\:\#]|$)")
+url_regex = re.compile(r"https?:\/\/[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}(?=[\/\:\#]|$)", re.UNICODE)
 def match_trackers(args):
     """
     Check if the substring is in the value and then check if any regex patterns match. First check for

--- a/processors/detect_trackers.py
+++ b/processors/detect_trackers.py
@@ -43,7 +43,7 @@ def match_trackers(args):
     for potential_url in potential_urls:
         if substring in potential_url:
             for regex in regex_list:
-                if regex["regex_pattern"].search(potential_url):
+                if regex["regex_pattern"].search(potential_url[0]): # Use the full match from the broad regex
                     matches.append((regex["regex_pattern"].pattern, regex["pattern_key"]))
     return matches
 

--- a/processors/detect_trackers.py
+++ b/processors/detect_trackers.py
@@ -41,9 +41,9 @@ def match_trackers(args):
     matches = []
     # Check if the substring is in the potential URLs
     for potential_url in potential_urls:
-        if substring in potential_url[0]:
+        if substring in potential_url:
             for regex in regex_list:
-                if regex["regex_pattern"].search(potential_url[0]): # Use the full match from the broad regex
+                if regex["regex_pattern"].search(potential_url): # Use the full match from the broad regex
                     matches.append((regex["regex_pattern"].pattern, regex["pattern_key"]))
     return matches
 
@@ -147,7 +147,7 @@ class DetectTrackers(BasicProcessor):
                     
                     # Extract URLs from the value
                     potential_urls = url_regex.findall(value)
-                    self.dataset.log("Potential URLs: %s" % potential_urls)
+                    # self.dataset.log("Potential URLs: %s" % potential_urls)
 
                     # Search for trackers
                     results = pool.map(

--- a/processors/detect_trackers.py
+++ b/processors/detect_trackers.py
@@ -41,7 +41,7 @@ def match_trackers(args):
     matches = []
     # Check if the substring is in the potential URLs
     for potential_url in potential_urls:
-        if substring in potential_url:
+        if substring in potential_url[0]:
             for regex in regex_list:
                 if regex["regex_pattern"].search(potential_url[0]): # Use the full match from the broad regex
                     matches.append((regex["regex_pattern"].pattern, regex["pattern_key"]))
@@ -147,6 +147,7 @@ class DetectTrackers(BasicProcessor):
                     
                     # Extract URLs from the value
                     potential_urls = url_regex.findall(value)
+                    self.dataset.log("Potential URLs: %s" % potential_urls)
 
                     # Search for trackers
                     results = pool.map(

--- a/processors/detect_trackers.py
+++ b/processors/detect_trackers.py
@@ -36,15 +36,16 @@ def match_trackers(args):
     :param value: Value to check against
     :return: List of tuples containing the regex pattern and the pattern key
     """
+    potential_urls = set(potential_urls)
     substring, regex_list, potential_urls = args
     # Extract URLs from the value
-    matches = []
+    matches = set()
     # Check if the substring is in the potential URLs
     for potential_url in potential_urls:
         if substring in potential_url:
             for regex in regex_list:
                 if regex["regex_pattern"].search(potential_url): # Use the full match from the broad regex
-                    matches.append((regex["regex_pattern"].pattern, regex["pattern_key"]))
+                    matches.add((regex["regex_pattern"].pattern, regex["pattern_key"]))
     return matches
 
 

--- a/processors/detect_trackers.py
+++ b/processors/detect_trackers.py
@@ -25,7 +25,7 @@ __email__ = "4cat@oilab.eu"
 
 csv.field_size_limit(1024 * 1024 * 1024)
 
-def match_trackers(substring, regex_list, value):
+def match_trackers(args):
     """
     Check if the substring is in the value and then check if any regex patterns match. First check for
     the substring to speed up the search. If the substring is not found, skip regex matching.
@@ -35,6 +35,7 @@ def match_trackers(substring, regex_list, value):
     :param value: Value to check against
     :return: List of tuples containing the regex pattern and the pattern key
     """
+    substring, regex_list, value = args
     matches = []
     if substring in value:
         for regex in regex_list:
@@ -142,8 +143,8 @@ class DetectTrackers(BasicProcessor):
                     
                     # Search for trackers
                     results = pool.map(
-                        lambda args: match_trackers(args[0], args[1], value),
-                        trackersdb["regex_patterns"].items()
+                        match_trackers,
+                        [(substring, regex_list, value) for substring, regex_list in trackersdb["regex_patterns"].items()]
                     )
                     matches = [match for sublist in results for match in sublist]
 

--- a/processors/detect_trackers.py
+++ b/processors/detect_trackers.py
@@ -25,6 +25,7 @@ __email__ = "4cat@oilab.eu"
 
 csv.field_size_limit(1024 * 1024 * 1024)
 
+# Regex to match URLs; does not include query strings or fragments
 url_regex = re.compile(r"https?:\/\/[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}(?=[\/\:\#]|$)", re.UNICODE)
 def match_trackers(args):
     """
@@ -143,11 +144,9 @@ class DetectTrackers(BasicProcessor):
 
                     self.dataset.update_progress(i/self.source_dataset.num_rows)
                     self.dataset.update_status("Searching for trackers in item %i of %i" % (i+1, self.source_dataset.num_rows))
-                    self.dataset.log("Item %s" % self.get_item_label(item))
                     
                     # Extract URLs from the value
                     potential_urls = set(url_regex.findall(value))
-                    # self.dataset.log("Potential URLs: %s" % potential_urls)
 
                     # Search for trackers
                     results = pool.map(
@@ -155,16 +154,6 @@ class DetectTrackers(BasicProcessor):
                         [(substring, regex_list, potential_urls) for substring, regex_list in trackersdb["regex_patterns"].items()]
                     )
                     matches = [match for sublist in results for match in sublist]
-
-                    # for substring, regex_list in trackersdb["regex_patterns"].items():
-                    #     # Check for substring before using regex
-                    #     if substring in value:
-                    #         # Now check for exact regex pattern associated with substring
-                    #         for regex in regex_list:
-                    #             pattern_key = regex["pattern_key"]
-                    #             regex_pattern = regex["regex_pattern"]
-                    #             if regex_pattern.search(value):
-                    #                 matches.append((regex_pattern.pattern, pattern_key))
                             
                     if matches:
                         matching_items += 1

--- a/processors/detect_trackers.py
+++ b/processors/detect_trackers.py
@@ -36,7 +36,6 @@ def match_trackers(args):
     :param value: Value to check against
     :return: List of tuples containing the regex pattern and the pattern key
     """
-    potential_urls = set(potential_urls)
     substring, regex_list, potential_urls = args
     # Extract URLs from the value
     matches = set()
@@ -147,7 +146,7 @@ class DetectTrackers(BasicProcessor):
                     self.dataset.log("Item %s" % self.get_item_label(item))
                     
                     # Extract URLs from the value
-                    potential_urls = url_regex.findall(value)
+                    potential_urls = set(url_regex.findall(value))
                     # self.dataset.log("Potential URLs: %s" % potential_urls)
 
                     # Search for trackers

--- a/processors/detect_trackers.py
+++ b/processors/detect_trackers.py
@@ -36,9 +36,8 @@ def match_trackers(args):
     :param value: Value to check against
     :return: List of tuples containing the regex pattern and the pattern key
     """
-    substring, regex_list, value = args
+    substring, regex_list, potential_urls = args
     # Extract URLs from the value
-    potential_urls = url_regex.findall(value)
     matches = []
     # Check if the substring is in the potential URLs
     for potential_url in potential_urls:
@@ -146,10 +145,13 @@ class DetectTrackers(BasicProcessor):
                     self.dataset.update_status("Searching for trackers in item %i of %i" % (i+1, self.source_dataset.num_rows))
                     self.dataset.log("Item %s" % self.get_item_label(item))
                     
+                    # Extract URLs from the value
+                    potential_urls = url_regex.findall(value)
+
                     # Search for trackers
                     results = pool.map(
                         match_trackers,
-                        [(substring, regex_list, value) for substring, regex_list in trackersdb["regex_patterns"].items()]
+                        [(substring, regex_list, potential_urls) for substring, regex_list in trackersdb["regex_patterns"].items()]
                     )
                     matches = [match for sublist in results for match in sublist]
 


### PR DESCRIPTION
- Extract potential URLs once from HTML, then search the smaller result
- Use Pool to ensure regex search cannot block GIL and stop other processes