### PR TITLE
Add cookies as JSON to Selenium; pass cookies for Screenshot Generator and HTML/Text Scraper

### DIFF
--- a/datasources/url_scraper/search_webpages.py
+++ b/datasources/url_scraper/search_webpages.py
@@ -187,9 +187,14 @@ class SearchWithSelenium(SeleniumSearch):
                     # Check if any link from base_url are available
                     if not url_obj['subpage_links']:
                         # If not, use this pages links collected above
-                        # TODO could also use selenium detected links; results vary, check as they are also being stored
+                        # Format selenium_links to match scraped_links for deduping
+                        selenium_links = [{'url': link} for link in result['selenium_links']]
+                        # Combine and dedup selenium and beautifulsoup links
+                        combined_links = {link['url']: link for link in (selenium_links + result['scraped_links'])}.values()
+
                         # Randomize links (else we end up with mostly menu items at the top of webpages)
-                        random.shuffle(links)
+                        random.shuffle(list(combined_links))
+                        links = list(combined_links)
                     else:
                         links = url_obj['subpage_links']
 

--- a/datasources/url_scraper/search_webpages.py
+++ b/datasources/url_scraper/search_webpages.py
@@ -45,6 +45,40 @@ class SearchWithSelenium(SeleniumSearch):
                 "type": UserInput.OPTION_TEXT_LARGE,
                 "help": "List of urls"
             },
+            "advanced-options-toggle": {
+                "type": UserInput.OPTION_CHOICE,
+                "help": "Show advanced options",
+                "options": {
+                    "false": "No",
+                    "true": "Yes"
+                },
+                "default": "false"
+            },
+            "intro-cookies": {
+                "type": UserInput.OPTION_INFO,
+                "help": "The following options can be used to add user cookies to the browser. This can be useful for sites that require a login or that show cookie "
+                        "walls before allowing access to the site content. These options may not work for all sites and may lead to unexpected results, such as "
+                        "missing screenshots or incomplete page loads. *This may also result in blocked access to some sites or even banning*. You can use tools such as "
+                        "[Cookie-Editor](https://addons.mozilla.org/en-US/firefox/addon/cookie-editor/) to copy your brower's cookies.",
+                "requires": "advanced-options-toggle==true"
+            },
+            "cookies-toggle": {
+                "type": UserInput.OPTION_CHOICE,
+                "help": "Upload cookies format",
+                "options": {
+                    "none": "Don't add user cookies",
+                    "json": "Add user cookies in JSON format",
+                    },
+                "default": "none",
+                "requires": "advanced-options-toggle==true"
+            },
+            "add_user_cookies_json": {
+                "type": UserInput.OPTION_TEXT_JSON,
+                "help": "Cookies in JSON format",
+                "default": [],
+                "tooltip": 'e.g. [{"name": "cookie1", "value": "value1", "domain": ".example.com"}, {"name": "cookie2", "value": "value2", "domain": ".example.com"}]',
+                "requires": ["advanced-options-toggle==true", "cookies-toggle==json"],
+            },
 
         }
         if config.get("selenium.display_advanced_options", default=False):
@@ -68,6 +102,9 @@ class SearchWithSelenium(SeleniumSearch):
         """
         scrape_additional_subpages = self.parameters.get("subpages", 0)
         urls_to_scrape = [{'url':url, 'base_url':url, 'num_additional_subpages': scrape_additional_subpages, 'subpage_links':[]} for url in query.get('urls')]
+
+        # Cookies
+        user_cookies = self.parameters.get("add_user_cookies_json", []) if self.parameters.get("cookies-toggle") == "json" else []
 
         # Do not scrape the same site twice
         scraped_urls = set()
@@ -110,7 +147,7 @@ class SearchWithSelenium(SeleniumSearch):
             while attempts < 2:
                 attempts += 1
                 try:
-                    scraped_page = self.simple_scrape_page(url, extract_links=True)
+                    scraped_page = self.simple_scrape_page(url, extract_links=True, user_cookies=user_cookies)
                 except Exception as e:
                     self.dataset.log('Url %s unable to be scraped with error: %s' % (url, str(e)))
                     self.restart_selenium()
@@ -168,7 +205,7 @@ class SearchWithSelenium(SeleniumSearch):
 
                     result['embedded_iframes'].append(link)
                     try:
-                        iframe_page = self.simple_scrape_page(link, extract_links=True)
+                        iframe_page = self.simple_scrape_page(link, extract_links=True, user_cookies=user_cookies)
                     except Exception as e:
                         self.dataset.log(f"Unable to collect iframe page source found on {scraped_page.get('final_url')}: {link} with error: {str(e)}")
                         continue
@@ -299,5 +336,7 @@ class SearchWithSelenium(SeleniumSearch):
 
         return {
             "urls": validated_urls,
-            "subpages": query.get("subpages", 0)
+            "subpages": query.get("subpages", 0),
+            "cookies-toggle": query.get("cookies-toggle", "none"),
+            "add_user_cookies_json": query.get("add_user_cookies_json", []) if query.get("cookies-toggle") == "json" else []
             }

--- a/datasources/url_screenshots/search_webpage_screenshots.py
+++ b/datasources/url_screenshots/search_webpage_screenshots.py
@@ -91,9 +91,13 @@ class ScreenshotWithSelenium(SeleniumSearch):
                 "max": 30,
             },
             "advanced-options-toggle": {
-                "type": UserInput.OPTION_TOGGLE,
+                "type": UserInput.OPTION_CHOICE,
                 "help": "Show advanced options",
-                "default": False
+                "options": {
+                    "false": "No",
+                    "true": "Yes"
+                },
+                "default": "false"
             },
             "intro-cookies": {
                 "type": UserInput.OPTION_INFO,
@@ -101,7 +105,7 @@ class ScreenshotWithSelenium(SeleniumSearch):
                         "walls before allowing access to the site content. These options may not work for all sites and may lead to unexpected results, such as "
                         "missing screenshots or incomplete page loads. *This may also result in blocked access to some sites or even banning*. You can use tools such as "
                         "[Cookie-Editor](https://addons.mozilla.org/en-US/firefox/addon/cookie-editor/) to copy your brower's cookies.",
-                "requires": "advanced-options-toggle==True"
+                "requires": "advanced-options-toggle==true"
             },
             "cookies-toggle": {
                 "type": UserInput.OPTION_CHOICE,
@@ -111,14 +115,14 @@ class ScreenshotWithSelenium(SeleniumSearch):
                     "json": "Add user cookies in JSON format",
                     },
                 "default": "none",
-                "requires": "advanced-options-toggle==True"
+                "requires": "advanced-options-toggle==true"
             },
             "add_user_cookies_json": {
                 "type": UserInput.OPTION_TEXT_JSON,
                 "help": "Cookies in JSON format",
                 "default": [],
                 "tooltip": 'e.g. [{"name": "cookie1", "value": "value1", "domain": ".example.com"}, {"name": "cookie2", "value": "value2", "domain": ".example.com"}]',
-                "requires": ["advanced-options-toggle==True", "cookies-toggle==json"],
+                "requires": ["advanced-options-toggle==true", "cookies-toggle==json"],
             },
         }
         if config.get('selenium.firefox_extensions') and config.get('selenium.firefox_extensions', default={}).get('i_dont_care_about_cookies', {}).get('path'):

--- a/datasources/url_screenshots/search_webpage_screenshots.py
+++ b/datasources/url_screenshots/search_webpage_screenshots.py
@@ -90,13 +90,43 @@ class ScreenshotWithSelenium(SeleniumSearch):
                 "min": 0,
                 "max": 30,
             },
+            "advanced-options-toggle": {
+                "type": UserInput.OPTION_TOGGLE,
+                "help": "Show advanced options",
+                "default": False
+            },
+            "intro-cookies": {
+                "type": UserInput.OPTION_INFO,
+                "help": "The following options can be used to add user cookies to the browser. This can be useful for sites that require a login or that show cookie "
+                        "walls before allowing access to the site content. These options may not work for all sites and may lead to unexpected results, such as "
+                        "missing screenshots or incomplete page loads. *This may also result in blocked access to some sites or even banning*. You can use tools such as "
+                        "[Cookie-Editor](https://addons.mozilla.org/en-US/firefox/addon/cookie-editor/) to copy your brower's cookies.",
+                "requires": "advanced-options-toggle==True"
+            },
+            "cookies-toggle": {
+                "type": UserInput.OPTION_CHOICE,
+                "help": "Upload cookies format",
+                "options": {
+                    "none": "Don't add user cookies",
+                    "json": "Add user cookies in JSON format",
+                    },
+                "default": "none",
+                "requires": "advanced-options-toggle==True"
+            },
+            "add_user_cookies_json": {
+                "type": UserInput.OPTION_TEXT_JSON,
+                "help": "Cookies in JSON format",
+                "default": [],
+                "tooltip": 'e.g. [{"name": "cookie1", "value": "value1", "domain": ".example.com"}, {"name": "cookie2", "value": "value2", "domain": ".example.com"}]',
+                "requires": ["advanced-options-toggle==True", "cookies-toggle==json"],
+            },
         }
         if config.get('selenium.firefox_extensions') and config.get('selenium.firefox_extensions', default={}).get('i_dont_care_about_cookies', {}).get('path'):
             options["ignore-cookies"] = {
                "type": UserInput.OPTION_TOGGLE,
                "help": "Attempt to ignore cookie walls",
                "default": False,
-               "tooltip": 'If enabled, a firefox extension will attempt to "agree" to any cookie walls automatically.'
+               "tooltip": 'If enabled, a Firefox extension will attempt to "agree" to any cookie walls automatically.'
             }
 
         return options
@@ -115,6 +145,9 @@ class ScreenshotWithSelenium(SeleniumSearch):
         pause = self.parameters.get("pause-time")
         wait = self.parameters.get("wait-time")
 
+        # Cookies
+        user_cookies = self.parameters.get("add_user_cookies_json", []) if self.parameters.get("cookies-toggle") == "json" else []
+        
         width = convert_to_int(resolution.split("x")[0], 1024)
         height = convert_to_int(resolution.split("x").pop(), 786) if capture == "viewport" else None
 
@@ -165,7 +198,7 @@ class ScreenshotWithSelenium(SeleniumSearch):
 
                 attempts += 1
                 start_time = time.time()
-                get_success, errors = self.get_with_error_handling(url, max_attempts=1, wait=wait, restart_browser=True)
+                get_success, errors = self.get_with_error_handling(url, cookie_jar=user_cookies, max_attempts=1, wait=wait, restart_browser=True)
                 if errors:
                     # Even if success, it is possible to have errors on earlier attempts
                     [result['error'].append("Attempt %i: %s" % (attempts + i, str(error))) for i, error in enumerate(errors)]

--- a/selenium_scraper.py
+++ b/selenium_scraper.py
@@ -61,6 +61,9 @@ class SeleniumWrapper(metaclass=abc.ABCMeta):
     consecutive_errors = 0
     num_consecutive_errors_before_restart = 3
 
+    _temp_profile_path = None
+    _temp_profile_is_temp = False
+
     def setup(self, config):
         """
         Setup the SeleniumWrapper. This injects the config object and sets up the logger.
@@ -117,21 +120,69 @@ class SeleniumWrapper(metaclass=abc.ABCMeta):
     def add_cookies(driver, cookies, url=None):
         """
         Add a cookie or list of cookies to a Selenium `driver`.
+
+        Tries three strategies per cookie to maximise compatibility across driver versions:
+          1. Full fidelity  — cookie dict as-is (expiry coerced to int).
+          2. W3C pruned     — drop keys not in the W3C WebDriver spec (handles drivers that
+                              reject unknown fields); sameSite is included here since modern
+                              geckodriver supports it.
+          3. Minimal safe   — name/value/domain/path/secure/httpOnly/expiry only (broadest
+                              compatibility with older drivers).
+
         cookies: dict or list of dicts. Each cookie must include 'name' and 'value'.
-                Optional keys: 'domain', 'path', 'expiry' (unix seconds), 'secure', 'httpOnly'.
-        url: optional full URL (scheme+host) to navigate to first — required if cookie domain must match.
+                 Optional keys: 'domain', 'path', 'expiry' (unix seconds), 'secure',
+                 'httpOnly', 'sameSite'.
+        url: optional full URL (scheme+host) to navigate to first — required if cookie
+             domain must match current page origin.
+
+        Returns a list of (cookie_name, exception) tuples for cookies that could not be
+        added under any strategy.
         """
         if not isinstance(cookies, (list, tuple)):
             cookies = [cookies]
         if url:
             driver.get(url)
-        allowed = {'name', 'value', 'path', 'domain', 'secure', 'httpOnly', 'expiry'}
+
+        # Keys accepted by modern W3C WebDriver (geckodriver ≥ 0.30, chromedriver ≥ 100)
+        _w3c_keys = {'name', 'value', 'path', 'domain', 'secure', 'httpOnly', 'expiry', 'sameSite'}
+        # Minimal set for older/stricter driver versions
+        _minimal_keys = {'name', 'value', 'path', 'domain', 'secure', 'httpOnly', 'expiry'}
+
+        failures = []
         for c in cookies:
             cookie = c.copy()
+            # Coerce expiry to int; remove it if not convertible
             if 'expiry' in cookie and cookie['expiry'] is not None:
-                cookie['expiry'] = int(cookie['expiry'])
-            cookie = {k: v for k, v in cookie.items() if k in allowed and v is not None}
-            driver.add_cookie(cookie)
+                try:
+                    cookie['expiry'] = int(cookie['expiry'])
+                except (TypeError, ValueError):
+                    del cookie['expiry']
+            name = cookie.get('name', '<unknown>')
+
+            # Strategy 1: full cookie dict as-is
+            try:
+                driver.add_cookie(cookie)
+                continue
+            except Exception:
+                pass
+
+            # Strategy 2: W3C keys (drops any custom/unknown fields the driver rejects)
+            try:
+                pruned_w3c = {k: v for k, v in cookie.items() if k in _w3c_keys and v is not None}
+                driver.add_cookie(pruned_w3c)
+                continue
+            except Exception:
+                pass
+
+            # Strategy 3: minimal safe set
+            try:
+                pruned_min = {k: v for k, v in cookie.items() if k in _minimal_keys and v is not None}
+                driver.add_cookie(pruned_min)
+                continue
+            except Exception as e_min:
+                failures.append((name, e_min))
+
+        return failures
 
     def _normalize_domain(self, domain: str):
         """Normalize a cookie domain (strip leading dot and lower-case)."""
@@ -206,15 +257,73 @@ class SeleniumWrapper(metaclass=abc.ABCMeta):
             scheme = 'https' if any(c.get('secure') for c in cookies) else 'http'
             origin = f"{scheme}://{domain}"
 
+            # Navigate to domain once to set context for cookies; required for Selenium to accept them
+            self.driver.get(origin)  
+
             try:
-                # Use the static helper which may navigate if origin provided
-                type(self).add_cookies(self.driver, cookies, url=origin)
+                # Log cookie info for debugging (dataset log avoids raw values)
+                for ck in cookies:
+                    name = ck.get('name')
+                    cookie_domain = ck.get('domain', domain)
+                    path = ck.get('path', '/')
+                    secure = bool(ck.get('secure', False))
+                    httpOnly = bool(ck.get('httpOnly', False))
+                    expiry = ck.get('expiry', None)
+                    value = ck.get('value', None)
+                    value_len = len(str(value)) if value is not None else 0
+                    try:
+                        if hasattr(self, 'dataset') and self.dataset:
+                            self.dataset.log(f"Applying cookie '{name}' for domain '{cookie_domain}' (path={path}, secure={secure}, httpOnly={httpOnly}, expiry={expiry}, value_len={value_len})")
+                    except Exception:
+                        pass
+                    try:
+                        if hasattr(self, 'selenium_log') and self.selenium_log:
+                            # debug-level log may contain full cookie dict for deeper inspection
+                            self.selenium_log.debug(f"Cookie detail for {cookie_domain}: {ck}")
+                    except Exception:
+                        pass
+
+                # Add cookies; add_cookies() returns (name, exc) pairs for any that failed
+                add_failures = type(self).add_cookies(self.driver, cookies)
                 self._cookie_domains_applied.add(domain)
+
+                # Log per-cookie failures (all three strategies exhausted)
+                for cookie_name, exc in (add_failures or []):
+                    msg = f"Failed to add cookie '{cookie_name}' for {domain} (all strategies): {type(exc).__name__}: {repr(exc)}"
+                    if self.selenium_log:
+                        self.selenium_log.warning(msg)
+                    errors.append(exc)
+
+                # Verify which cookies landed and log discrepancies to aid debugging
+                try:
+                    present = {c['name']: c for c in self.driver.get_cookies()}
+                    for ck in cookies:
+                        cname = ck.get('name')
+                        if not cname:
+                            continue
+                        cur = present.get(cname)
+                        if not cur:
+                            if self.selenium_log:
+                                self.selenium_log.warning(f"Cookie '{cname}' not present in browser after add (domain={domain})")
+                        else:
+                            diffs = []
+                            for key in ('value', 'domain', 'path', 'secure', 'httpOnly', 'expiry', 'sameSite'):
+                                req_val = ck.get(key)
+                                got_val = cur.get(key)
+                                if req_val is None and got_val is None:
+                                    continue
+                                if str(req_val) != str(got_val):
+                                    diffs.append((key, req_val, got_val))
+                            if diffs and self.selenium_log:
+                                self.selenium_log.debug(f"Cookie '{cname}' stored with diffs vs requested: {diffs}")
+                except Exception:
+                    pass
+
             except Exception as e:
-                # log and keep going
+                # Catch unexpected errors from the overall block (navigation, etc.)
                 try:
                     if hasattr(self, 'selenium_log') and self.selenium_log:
-                        self.selenium_log.warning(f"Error adding cookies for {domain}: {e}")
+                        self.selenium_log.warning(f"Error applying cookies for {domain}: {type(e).__name__}: {repr(e)}")
                 except Exception:
                     pass
                 errors.append(e)
@@ -292,7 +401,7 @@ class SeleniumWrapper(metaclass=abc.ABCMeta):
 
             if attempts < max_attempts:
                 time.sleep(wait)
-
+        self.selenium_log.info(f"Current cookies: {self.driver.get_cookies() if self.driver else 'N/A'}")
         return success, errors
 
     def simple_scrape_page(self, url, extract_links=False, title_404_strings='default'):
@@ -427,18 +536,32 @@ class SeleniumWrapper(metaclass=abc.ABCMeta):
         # Configure virtual display vs headless mode
         self.setup_virtual_display_mode(options, "firefox")
        
-        # Firefox-specific optimizations - no profile creation for speed
+        # Resolve profile first so we can decide whether to start in private mode.
+        # A user-configured path takes priority; if none is set, create a fresh temp profile
+        # for this session so each job gets a clean, isolated browser context.
+        profile_path = None
+        try:
+            profile_path = self.get_profile()
+            if not profile_path:
+                profile_path = self._create_temp_profile()
+        except Exception as e:
+            self.selenium_log.warning(f"Could not resolve Firefox profile: {e}")
+
+        # Firefox-specific options
         options.add_argument('--no-sandbox')
         options.add_argument("--disable-gpu")
         options.add_argument("--disable-extensions")
-        options.add_argument("--private")
-        
-        # Set preferences directly in options to avoid profile creation
+
+        # Base preferences
         options.set_preference("dom.webdriver.enabled", False)
         options.set_preference('useAutomationExtension', False)
-        options.set_preference("browser.privatebrowsing.autostart", True)
         options.set_preference("browser.cache.disk.enable", False)
         options.set_preference("browser.cache.memory.enable", False)
+
+        if not profile_path:
+            # No profile available — use private mode for basic session isolation
+            options.add_argument("--private")
+            options.set_preference("browser.privatebrowsing.autostart", True)
         # Optionally adjust prefs that reduce disruptive dialogs; kept behind config for stealth
         if self.config.get('selenium.reduce_dialog_prefs', False):
             options.set_preference("dom.webnotifications.enabled", False)
@@ -504,14 +627,10 @@ class SeleniumWrapper(metaclass=abc.ABCMeta):
             options.binary_location = firefox_binary
             self.selenium_log.info(f"Using custom Firefox binary: {firefox_binary}")
 
-        # Use configured/overridden profile via get_profile()
-        try:
-            profile_path = self.get_profile()
-            if profile_path and os.path.exists(profile_path):
-                options.add_argument(f'--profile={profile_path}')
-                self.selenium_log.info(f"Using custom Firefox profile: {profile_path}")
-        except Exception as e:
-            self.selenium_log.debug(f"No Firefox profile provided via get_profile(): {e}")
+        # Apply the resolved profile (user-provided or temp)
+        if profile_path:
+            options.add_argument(f'--profile={profile_path}')
+            self.selenium_log.info(f"Using Firefox profile: {profile_path}")
 
         try:
             # Create Firefox service with configurable geckodriver path
@@ -691,6 +810,73 @@ class SeleniumWrapper(metaclass=abc.ABCMeta):
             self.selenium_log.warning(f"get_profile() error: {e}")
             return None
         
+    def _create_temp_profile(self):
+        """
+        Create a fresh, isolated browser profile directory for this session.
+
+        The path is derived from PATH_DATA, the dataset key (if available) and the browser
+        type, so the directory name is predictable and easy to audit/clean up manually.
+        The caller is responsible for passing the path to the browser (e.g. via --profile).
+
+        Sets self._temp_profile_path and self._temp_profile_is_temp = True.
+
+        :return str: Absolute path to the created profile directory.
+        """
+        # Build a human-readable, collision-resistant name
+        dataset_key = getattr(self.dataset, 'key', None) if hasattr(self, 'dataset') else None
+        browser = self.browser or 'firefox'
+        if dataset_key:
+            profile_name = f"{dataset_key}_{browser}_temp_profile"
+        else:
+            # Fallback: timestamp + pid so concurrent workers don't collide
+            import datetime
+            profile_name = f"{datetime.datetime.now().strftime('%Y%m%d%H%M%S')}_{os.getpid()}_{browser}_temp_profile"
+
+        try:
+            base_dir = self.config.get('PATH_DATA')
+            profile_path = str(base_dir.joinpath(profile_name))
+        except Exception:
+            # Last resort: system temp dir
+            import tempfile
+            profile_path = os.path.join(tempfile.gettempdir(), profile_name)
+
+        os.makedirs(profile_path, exist_ok=True)
+        self._temp_profile_path = profile_path
+        self._temp_profile_is_temp = True
+        self.selenium_log.info(f"Created temporary Firefox profile: {profile_path}")
+        try:
+            if hasattr(self, 'dataset') and self.dataset:
+                self.dataset.log(f"Created temporary Firefox profile: {profile_path}")
+        except Exception:
+            pass
+        return profile_path
+
+    def _remove_temp_profile(self):
+        """
+        Remove the temporary profile directory created by _create_temp_profile(), if any.
+        Only removes directories we created ourselves (self._temp_profile_is_temp == True).
+        User-provided profile paths are never deleted.
+        """
+        if not self._temp_profile_is_temp or not self._temp_profile_path:
+            return
+        path = self._temp_profile_path
+        self._temp_profile_path = None
+        self._temp_profile_is_temp = False
+        if not os.path.exists(path):
+            return
+        try:
+            shutil.rmtree(path, ignore_errors=False)
+            self.selenium_log.info(f"Removed temporary Firefox profile: {path}")
+        except Exception as e:
+            # On Windows, Firefox may briefly hold file locks after quit(); retry once
+            self.selenium_log.warning(f"Could not remove temp profile on first attempt ({e}); retrying in 2s")
+            time.sleep(2)
+            shutil.rmtree(path, ignore_errors=True)
+            if not os.path.exists(path):
+                self.selenium_log.info(f"Removed temporary Firefox profile (retry): {path}")
+            else:
+                self.selenium_log.warning(f"Temp profile may still exist at {path}; manual cleanup may be needed")
+
     def apply_common_driver_config(self):
         """
         Apply common driver configuration after driver creation.
@@ -742,6 +928,9 @@ class SeleniumWrapper(metaclass=abc.ABCMeta):
 
         # Stop virtual display (only if we started it)
         self.stop_virtual_display()
+
+        # Remove temp profile if we created it for this session
+        self._remove_temp_profile()
 
     def restart_selenium(self, eager=None, kill_browser=False):
         """

--- a/selenium_scraper.py
+++ b/selenium_scraper.py
@@ -228,16 +228,16 @@ class SeleniumWrapper(metaclass=abc.ABCMeta):
         """
         errors = []
         if not cookie_jar:
-            return errors
+            return [Exception("No cookies provided in cookie_jar")]
         if not self.driver:
-            return errors
+            return [Exception("Selenium driver not initialized")]
 
         try:
             host = urlparse(url).hostname
         except Exception:
             host = None
         if not host:
-            return errors
+            return [Exception("Invalid URL or unable to extract hostname")]
 
         grouped = self._group_cookies_by_domain(cookie_jar, default_host=host)
         # Ensure cache exists
@@ -261,28 +261,6 @@ class SeleniumWrapper(metaclass=abc.ABCMeta):
             self.driver.get(origin)  
 
             try:
-                # Log cookie info for debugging (dataset log avoids raw values)
-                for ck in cookies:
-                    name = ck.get('name')
-                    cookie_domain = ck.get('domain', domain)
-                    path = ck.get('path', '/')
-                    secure = bool(ck.get('secure', False))
-                    httpOnly = bool(ck.get('httpOnly', False))
-                    expiry = ck.get('expiry', None)
-                    value = ck.get('value', None)
-                    value_len = len(str(value)) if value is not None else 0
-                    try:
-                        if hasattr(self, 'dataset') and self.dataset:
-                            self.dataset.log(f"Applying cookie '{name}' for domain '{cookie_domain}' (path={path}, secure={secure}, httpOnly={httpOnly}, expiry={expiry}, value_len={value_len})")
-                    except Exception:
-                        pass
-                    try:
-                        if hasattr(self, 'selenium_log') and self.selenium_log:
-                            # debug-level log may contain full cookie dict for deeper inspection
-                            self.selenium_log.debug(f"Cookie detail for {cookie_domain}: {ck}")
-                    except Exception:
-                        pass
-
                 # Add cookies; add_cookies() returns (name, exc) pairs for any that failed
                 add_failures = type(self).add_cookies(self.driver, cookies)
                 self._cookie_domains_applied.add(domain)
@@ -295,29 +273,29 @@ class SeleniumWrapper(metaclass=abc.ABCMeta):
                     errors.append(exc)
 
                 # Verify which cookies landed and log discrepancies to aid debugging
-                try:
-                    present = {c['name']: c for c in self.driver.get_cookies()}
-                    for ck in cookies:
-                        cname = ck.get('name')
-                        if not cname:
-                            continue
-                        cur = present.get(cname)
-                        if not cur:
-                            if self.selenium_log:
+                if hasattr(self, 'selenium_log') and self.selenium_log and self.selenium_log.isEnabledFor(logging.DEBUG):
+                    try:
+                        present = {c['name']: c for c in self.driver.get_cookies()}
+                        for ck in cookies:
+                            cname = ck.get('name')
+                            if not cname:
+                                continue
+                            cur = present.get(cname)
+                            if not cur:
                                 self.selenium_log.warning(f"Cookie '{cname}' not present in browser after add (domain={domain})")
-                        else:
-                            diffs = []
-                            for key in ('value', 'domain', 'path', 'secure', 'httpOnly', 'expiry', 'sameSite'):
-                                req_val = ck.get(key)
-                                got_val = cur.get(key)
-                                if req_val is None and got_val is None:
-                                    continue
-                                if str(req_val) != str(got_val):
-                                    diffs.append((key, req_val, got_val))
-                            if diffs and self.selenium_log:
-                                self.selenium_log.debug(f"Cookie '{cname}' stored with diffs vs requested: {diffs}")
-                except Exception:
-                    pass
+                            else:
+                                diffs = []
+                                for key in ('value', 'domain', 'path', 'secure', 'httpOnly', 'expiry', 'sameSite'):
+                                    req_val = ck.get(key)
+                                    got_val = cur.get(key)
+                                    if req_val is None and got_val is None:
+                                        continue
+                                    if str(req_val) != str(got_val):
+                                        diffs.append((key, req_val, got_val))
+                                if diffs:
+                                    self.selenium_log.debug(f"Cookie '{cname}' stored with diffs vs requested: {diffs}")
+                    except Exception as e:
+                        self.selenium_log.warning(f"Error verifying cookies for {domain}: {type(e).__name__}: {repr(e)}")
 
             except Exception as e:
                 # Catch unexpected errors from the overall block (navigation, etc.)
@@ -401,7 +379,7 @@ class SeleniumWrapper(metaclass=abc.ABCMeta):
 
             if attempts < max_attempts:
                 time.sleep(wait)
-        self.selenium_log.info(f"Current cookies: {self.driver.get_cookies() if self.driver else 'N/A'}")
+        # self.selenium_log.debug(f"Current cookies: {self.driver.get_cookies() if self.driver else 'N/A'}")
         return success, errors
 
     def simple_scrape_page(self, url, extract_links=False, title_404_strings='default', wait=0, max_attempts=1, user_cookies=None):

--- a/selenium_scraper.py
+++ b/selenium_scraper.py
@@ -404,7 +404,7 @@ class SeleniumWrapper(metaclass=abc.ABCMeta):
         self.selenium_log.info(f"Current cookies: {self.driver.get_cookies() if self.driver else 'N/A'}")
         return success, errors
 
-    def simple_scrape_page(self, url, extract_links=False, title_404_strings='default'):
+    def simple_scrape_page(self, url, extract_links=False, title_404_strings='default', wait=0, max_attempts=1, user_cookies=None):
         """
         Simple helper to scrape url. Returns a dictionary containing basic results from scrape including final_url,
         page_title, and page_source otherwise False if the page did not advance (self.check_for_movement() failed).
@@ -420,35 +420,77 @@ class SeleniumWrapper(metaclass=abc.ABCMeta):
                       Returns false if no movement was detected
         """
 
-        self.reset_current_page()
-        self.driver.get(url)
-
-        if self.check_for_movement():
-
-            results = self.collect_results(url, extract_links, title_404_strings)
-            return results
-
+        get_success, errors = self.get_with_error_handling(url, cookie_jar=user_cookies, max_attempts=max_attempts, wait=wait, restart_browser=True)
+        if get_success:
+            result = self.collect_results(url, extract_links, title_404_strings)
+            if errors:
+                result['errors'].extend(errors)
+            return result
         else:
-            raise Exception("Failed to navigate to new page; check url is not the same as previous url")
+            if errors:
+                return {'errors': errors}
+            return False
+
 
     def collect_results(self, url, extract_links=False, title_404_strings='default'):
+        """
+        Collect results from the current page. Returns a dictionary containing basic results from scrape including final_url,
+        page_title, and page_source. Optionally can include links if extract_links is True. Handles errors from driver.title, driver.current_url, and driver.page_source gracefully by logging the error and including it in the returned dictionary under an 'errors' key as a list of error messages. Note that if an error occurs when trying to access any of these properties, the corresponding value in the returned dictionary will be an empty string.
+
+        :param str url:  url as string; beginning with scheme (e.g., http, https)
+        :param bool extract_links:  Whether to extract links from the page
+        :param List title_404_strings:  List of strings representing possible 404 text to be compared with driver.title
+        :return dict: A dictionary containing basic results from scrape including final_url, page_title, and page_source.
+        """
+        errors = []
+        try:
+            detected_404 = self.check_for_404(title_404_strings)
+        except Exception as e:
+            self.selenium_log.warning(f"Error checking for 404: {e}")
+            errors.append(e)
+            detected_404 = False
+        try:
+            title = self.driver.title
+        except Exception as e:
+            self.selenium_log.warning(f"Error getting page title: {e}")
+            errors.append(e)
+            title = ""
+        try:
+            final_url = self.driver.current_url
+        except Exception as e:
+            self.selenium_log.warning(f"Error getting final URL: {e}")
+            errors.append(e)
+            final_url = ""
+        try:
+            page_source = self.driver.page_source
+        except Exception as e:
+            self.selenium_log.warning(f"Error getting page source: {e}")
+            errors.append(e)
+            page_source = ""
 
         result = {
             'original_url': url,
-            'detected_404': self.check_for_404(title_404_strings),
-            'page_title': self.driver.title,
-            'final_url': self.driver.current_url,
-            'page_source': self.driver.page_source,
+            'detected_404': detected_404,
+            'page_title': title,
+            'final_url': final_url,
+            'page_source': page_source,
+            'errors': errors
             }
 
         if extract_links:
-            result['links'] = self.collect_links()
+            try:
+                result['links'] = self.collect_links()
+            except Exception as e:
+                self.selenium_log.warning(f"Error collecting links: {e}")
+                result['errors'].append(e)
+
+        result["success"] = True if final_url and page_source and not detected_404 else False
 
         return result
 
     def collect_links(self):
         """
-
+        Collect all links on the current page. Returns a list of URLs (strings).
         """
         if self.driver is None:
             raise ProcessorException('Selenium Drive not yet started: Cannot collect links')

--- a/selenium_scraper.py
+++ b/selenium_scraper.py
@@ -113,7 +113,115 @@ class SeleniumWrapper(metaclass=abc.ABCMeta):
                 return True, "", "", current
         return False, "", "", current
 
-    def get_with_error_handling(self, url, max_attempts=1, wait=0, restart_browser=True):
+    @staticmethod
+    def add_cookies(driver, cookies, url=None):
+        """
+        Add a cookie or list of cookies to a Selenium `driver`.
+        cookies: dict or list of dicts. Each cookie must include 'name' and 'value'.
+                Optional keys: 'domain', 'path', 'expiry' (unix seconds), 'secure', 'httpOnly'.
+        url: optional full URL (scheme+host) to navigate to first — required if cookie domain must match.
+        """
+        if not isinstance(cookies, (list, tuple)):
+            cookies = [cookies]
+        if url:
+            driver.get(url)
+        allowed = {'name', 'value', 'path', 'domain', 'secure', 'httpOnly', 'expiry'}
+        for c in cookies:
+            cookie = c.copy()
+            if 'expiry' in cookie and cookie['expiry'] is not None:
+                cookie['expiry'] = int(cookie['expiry'])
+            cookie = {k: v for k, v in cookie.items() if k in allowed and v is not None}
+            driver.add_cookie(cookie)
+
+    def _normalize_domain(self, domain: str):
+        """Normalize a cookie domain (strip leading dot and lower-case)."""
+        if not domain:
+            return None
+        return domain.lstrip('.').lower()
+
+    def _domain_matches(self, host: str, cookie_domain: str):
+        """Return True if `cookie_domain` applies to `host` (handles subdomains)."""
+        if not host or not cookie_domain:
+            return False
+        host = host.lower()
+        cd = self._normalize_domain(cookie_domain)
+        if host == cd:
+            return True
+        # match subdomains
+        return host.endswith('.' + cd)
+
+    def _group_cookies_by_domain(self, cookie_jar, default_host=None):
+        """Group a list of cookie dicts by normalized domain.
+
+        Cookies without a `domain` key are assigned to `default_host`.
+        Returns a dict: {normalized_domain: [cookie_dict, ...]}
+        """
+        grouped = {}
+        if not cookie_jar:
+            return grouped
+        for c in cookie_jar:
+            domain = c.get('domain')
+            if domain:
+                nd = self._normalize_domain(domain)
+            else:
+                nd = default_host.lower() if default_host else None
+            if not nd:
+                continue
+            grouped.setdefault(nd, []).append(c)
+        return grouped
+
+    def apply_cookies_for_url(self, url, cookie_jar):
+        """Apply cookies appropriate for `url` from `cookie_jar`.
+
+        Returns a list of errors encountered (empty if none).
+        """
+        errors = []
+        if not cookie_jar:
+            return errors
+        if not self.driver:
+            return errors
+
+        try:
+            host = urlparse(url).hostname
+        except Exception:
+            host = None
+        if not host:
+            return errors
+
+        grouped = self._group_cookies_by_domain(cookie_jar, default_host=host)
+        # Ensure cache exists
+        if not hasattr(self, '_cookie_domains_applied') or self._cookie_domains_applied is None:
+            self._cookie_domains_applied = set()
+
+        for domain, cookies in grouped.items():
+            # Only apply cookies that match the target host
+            if not self._domain_matches(host, domain) and domain != host:
+                continue
+
+            if domain in self._cookie_domains_applied:
+                # already applied for this session
+                continue
+
+            # choose scheme: prefer https if any cookie is secure
+            scheme = 'https' if any(c.get('secure') for c in cookies) else 'http'
+            origin = f"{scheme}://{domain}"
+
+            try:
+                # Use the static helper which may navigate if origin provided
+                type(self).add_cookies(self.driver, cookies, url=origin)
+                self._cookie_domains_applied.add(domain)
+            except Exception as e:
+                # log and keep going
+                try:
+                    if hasattr(self, 'selenium_log') and self.selenium_log:
+                        self.selenium_log.warning(f"Error adding cookies for {domain}: {e}")
+                except Exception:
+                    pass
+                errors.append(e)
+
+        return errors
+
+    def get_with_error_handling(self, url, max_attempts=1, wait=0, cookie_jar=None, restart_browser=True):
         """
         Attempts to call driver.get(url) with error handling. Will attempt to restart Selenium if it fails and can
         attempt to kill Firefox (and allow Selenium to restart) itself if allowed.
@@ -123,6 +231,7 @@ class SeleniumWrapper(metaclass=abc.ABCMeta):
         :param str url:                URL to retrieve
         :param int max_attempts:       Maximum number of attempts to retrieve the URL
         :param int wait:               Seconds to wait between attempts
+        :param list cookie_jar:        List of cookies to add to the driver
         :param bool restart_browser:   If True, will kill the browser process if too many consecutive errors occur
         """
         # Start clean
@@ -135,6 +244,16 @@ class SeleniumWrapper(metaclass=abc.ABCMeta):
         success = False
         attempts = 0
         errors = []
+
+        # Apply any user-provided cookies appropriate for this URL
+        if cookie_jar:
+            try:
+                cookie_errors = self.apply_cookies_for_url(url, cookie_jar)
+                if cookie_errors:
+                    # convert exceptions/messages into errors list for caller visibility
+                    [errors.append(e) for e in cookie_errors]
+            except Exception as e:
+                errors.append(e)
         while attempts < max_attempts:
             attempts += 1
             try:
@@ -286,6 +405,8 @@ class SeleniumWrapper(metaclass=abc.ABCMeta):
         elif self.browser is None:
             # Use configured default browser
             self.browser = self.config.get('selenium.browser')
+        # Track which domains we've already applied cookies for in this session
+        self._cookie_domains_applied = set()
         self.selenium_log.info(f"Starting Selenium with browser: {self.browser}")
         
         if self.browser != "firefox":
@@ -606,6 +727,11 @@ class SeleniumWrapper(metaclass=abc.ABCMeta):
             self.selenium_log.error(e)
         self.driver = None
         self.last_scraped_url = None
+        # Clear applied-cookie domain cache
+        try:
+            self._cookie_domains_applied = set()
+        except Exception:
+            pass
 
         if kill_browser:
             time.sleep(2)


### PR DESCRIPTION
Inject user-provided cookies into Selenium-based web scrapers and screenshot tools.

- Added advanced options in both `search_webpages.py` and `search_webpage_screenshots.py` for toggling cookie support, including UI fields for JSON cookie input, and informational tooltips about risks and usage.
- Updated `get_items` methods to extract and pass user cookie data through the scraping/screenshotting pipeline, ensuring cookies are used when selected by the user. 
- Introduced cookie injection methods in `selenium_scraper.py`; methods to add cookies to the browser, group cookies by domain, and apply them for a given URL (Selenium requires navigation to the specific domain before applying cookies).
- Added temporary Firefox profiles (needed to support cookies). They cleanup on selenium.quit().